### PR TITLE
Return the user's first and last name in the headers X-Forwarded-First-Name & X-Forwarded-Last-Name

### DIFF
--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -50,6 +50,8 @@ type redeemResponse struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
 	ExpiresIn    int64  `json:"expires_in"`
+	FirstName    string `json:"first_name"`
+	LastName     string `json:"last_name"`
 	Email        string `json:"email"`
 }
 
@@ -655,6 +657,8 @@ func (p *Authenticator) Redeem(rw http.ResponseWriter, req *http.Request) {
 		AccessToken:  session.AccessToken,
 		RefreshToken: session.RefreshToken,
 		ExpiresIn:    int64(session.RefreshDeadline.Sub(time.Now()).Seconds()),
+		FirstName:    session.FirstName,
+		LastName:     session.LastName,
 		Email:        session.Email,
 	}
 

--- a/internal/auth/providers/google_test.go
+++ b/internal/auth/providers/google_test.go
@@ -130,9 +130,10 @@ func TestGoogleProviderRedeem(t *testing.T) {
 				AccessToken:  "a1234",
 				ExpiresIn:    10,
 				RefreshToken: "refresh12345",
-				IDToken:      "ignored prefix." + base64.URLEncoding.EncodeToString([]byte(`{"email": "michael.bland@gsa.gov", "email_verified":true}`)),
+				IDToken:      "ignored prefix." + base64.URLEncoding.EncodeToString([]byte(`{"email": "michael.bland@gsa.gov", "email_verified":true, "name": "Michael Bland"}`)),
 			},
 			expectedSession: &sessions.SessionState{
+				Name:         "Michael Bland",
 				Email:        "michael.bland@gsa.gov",
 				AccessToken:  "a1234",
 				RefreshToken: "refresh12345",

--- a/internal/auth/providers/google_test.go
+++ b/internal/auth/providers/google_test.go
@@ -130,10 +130,11 @@ func TestGoogleProviderRedeem(t *testing.T) {
 				AccessToken:  "a1234",
 				ExpiresIn:    10,
 				RefreshToken: "refresh12345",
-				IDToken:      "ignored prefix." + base64.URLEncoding.EncodeToString([]byte(`{"email": "michael.bland@gsa.gov", "email_verified":true, "name": "Michael Bland"}`)),
+				IDToken:      "ignored prefix." + base64.URLEncoding.EncodeToString([]byte(`{"email": "michael.bland@gsa.gov", "email_verified":true, "given_name": "Michael", "family_name": "Bland"}`)),
 			},
 			expectedSession: &sessions.SessionState{
-				Name:         "Michael Bland",
+				FirstName:    "Michael",
+				LastName:     "Bland",
 				Email:        "michael.bland@gsa.gov",
 				AccessToken:  "a1234",
 				RefreshToken: "refresh12345",

--- a/internal/pkg/sessions/session_state.go
+++ b/internal/pkg/sessions/session_state.go
@@ -25,9 +25,11 @@ type SessionState struct {
 	ValidDeadline    time.Time `json:"valid_deadline"`
 	GracePeriodStart time.Time `json:"grace_period_start"`
 
-	Email  string   `json:"email"`
-	User   string   `json:"user"`
-	Groups []string `json:"groups"`
+	FirstName string   `json:"first_name"`
+	LastName  string   `json:"last_name"`
+	Email     string   `json:"email"`
+	User      string   `json:"user"`
+	Groups    []string `json:"groups"`
 }
 
 // LifetimePeriodExpired returns true if the lifetime has expired

--- a/internal/proxy/oauthproxy.go
+++ b/internal/proxy/oauthproxy.go
@@ -29,6 +29,8 @@ var SignatureHeaders = []string{
 	"Content-Type",
 	"Date",
 	"Authorization",
+	"X-Forwarded-First-Name",
+	"X-Forwarded-Last-Name",
 	"X-Forwarded-User",
 	"X-Forwarded-Email",
 	"X-Forwarded-Groups",
@@ -797,12 +799,16 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) (er
 		req.Header.Set(key, val)
 	}
 
+	fmt.Println(session)
+
 	req.Header.Set("X-Forwarded-User", session.User)
 
 	if p.passAccessToken && session.AccessToken != "" {
 		req.Header.Set("X-Forwarded-Access-Token", session.AccessToken)
 	}
 
+	req.Header.Set("X-Forwarded-First-Name", session.FirstName)
+	req.Header.Set("X-Forwarded-Last-Name", session.LastName)
 	req.Header.Set("X-Forwarded-Email", session.Email)
 	req.Header.Set("X-Forwarded-Groups", strings.Join(session.Groups, ","))
 

--- a/internal/proxy/oauthproxy_test.go
+++ b/internal/proxy/oauthproxy_test.go
@@ -88,6 +88,8 @@ func testSession() *sessions.SessionState {
 	theFuture := time.Now().AddDate(100, 100, 100)
 
 	return &sessions.SessionState{
+		FirstName:   "Michael",
+		LastName:    "Bland",
 		Email:       "michael.bland@gsa.gov",
 		AccessToken: "my_access_token",
 		Groups:      []string{"foo", "bar"},
@@ -396,10 +398,12 @@ func TestHeadersSentToUpstreams(t *testing.T) {
 
 			session := testSession()
 			expectedHeaders := map[string]string{
-				"X-Forwarded-Email":  session.Email,
-				"X-Forwarded-User":   session.User,
-				"X-Forwarded-Groups": strings.Join(session.Groups, ","),
-				"Cookie":             tc.expectedCookieHeader,
+				"X-Forwarded-Email":      session.Email,
+				"X-Forwarded-User":       session.User,
+				"X-Forwarded-First-Name": session.FirstName,
+				"X-Forwarded-Last-Name":  session.LastName,
+				"X-Forwarded-Groups":     strings.Join(session.Groups, ","),
+				"Cookie":                 tc.expectedCookieHeader,
 			}
 
 			for key, val := range expectedHeaders {

--- a/internal/proxy/providers/sso.go
+++ b/internal/proxy/providers/sso.go
@@ -149,6 +149,8 @@ func (p *SSOProvider) Redeem(redirectURL, code string) (*sessions.SessionState, 
 		AccessToken  string `json:"access_token"`
 		RefreshToken string `json:"refresh_token"`
 		ExpiresIn    int64  `json:"expires_in"`
+		FirstName    string `json:"first_name"`
+		LastName     string `json:"last_name"`
 		Email        string `json:"email"`
 	}
 	err = json.Unmarshal(body, &jsonResponse)
@@ -168,8 +170,10 @@ func (p *SSOProvider) Redeem(redirectURL, code string) (*sessions.SessionState, 
 		LifetimeDeadline: extendDeadline(p.SessionLifetimeTTL),
 		ValidDeadline:    extendDeadline(p.SessionValidTTL),
 
-		Email: jsonResponse.Email,
-		User:  user,
+		FirstName: jsonResponse.FirstName,
+		LastName:  jsonResponse.LastName,
+		Email:     jsonResponse.Email,
+		User:      user,
 	}, nil
 }
 

--- a/internal/proxy/request_signer.go
+++ b/internal/proxy/request_signer.go
@@ -24,6 +24,8 @@ var signedHeaders = []string{
 	"Content-Type",
 	"Date",
 	"Authorization",
+	"X-Forwarded-First-Name",
+	"X-Forwarded-Last-Name",
 	"X-Forwarded-User",
 	"X-Forwarded-Email",
 	"X-Forwarded-Groups",


### PR DESCRIPTION
## Problem

Buzzfeed's emails apparently follow the pattern of firstname.lastname@buzzfeed.com (i.e. ralph.wiggums@buzzfeed.com). For those who's emails don't follow this pattern (i.e rwiggums@soxhub.com), services behind the proxy will need to make an extra request for the name of the person associated with the email address. 

## Solution

Return the first and last name of the person associated with the email returned. The two new headers that are returned are X-Forwarded-First-Name and X-Forwarded-Last-Name

## Notes

Only did this for the Google provider as we do not use Okta